### PR TITLE
Dedicated Specification Objective Listing page, new Stakeholder Objective is blank by default

### DIFF
--- a/src/main/java/com/soam/web/specificationobjective/SpecificationObjectiveController.java
+++ b/src/main/java/com/soam/web/specificationobjective/SpecificationObjectiveController.java
@@ -1,0 +1,54 @@
+package com.soam.web.specificationobjective;
+
+import com.soam.model.specification.Specification;
+import com.soam.model.specification.SpecificationRepository;
+import com.soam.model.specificationobjective.SpecificationObjective;
+import com.soam.model.specificationobjective.SpecificationObjectiveRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Optional;
+
+@Controller
+@RequestMapping("/specification/{specificationId}")
+public class SpecificationObjectiveController {
+    private static final String VIEWS_SPECIFICATION_OBJECTIVE_LIST = "specificationObjective/specificationObjectiveList";
+    private static final String VIEWS_SPECIFICATION_OBJECTIVE_DETAILS = "specificationObjective/specificationObjectiveDetails";
+    private static final String REDIRECT_SPECIFICATION_DETAILS =  "redirect:/specification/%s";
+
+    private final SpecificationRepository specificationRepository;
+    private final SpecificationObjectiveRepository specificationObjectives;
+
+    public SpecificationObjectiveController(SpecificationRepository specificationRepository, SpecificationObjectiveRepository specificationObjectives) {
+        this.specificationRepository = specificationRepository;
+        this.specificationObjectives = specificationObjectives;
+    }
+
+    @ModelAttribute("specification")
+    public Specification populateSpecification(@PathVariable("specificationId") int specificationId) {
+        Optional<Specification> oSpecification = specificationRepository.findById(specificationId);
+        return oSpecification.orElse(null);
+    }
+
+    @GetMapping("/specificationObjective/list")
+    public String listSpecificationObjectives(Specification specification, Model model) {
+        model.addAttribute("specificationObjectives", specification.getSpecificationObjectives());
+        return VIEWS_SPECIFICATION_OBJECTIVE_LIST;
+    }
+
+    @GetMapping("/specificationObjective/{specificationObjectiveId}")
+    public String showSpecificationObjective(
+            Specification specification,
+            @PathVariable("specificationObjectiveId") int specificationObjectiveId, Model model) {
+        Optional<SpecificationObjective> maybeSpecificationObjective = this.specificationObjectives.findById(specificationObjectiveId);
+        if (maybeSpecificationObjective.isEmpty()) {
+            return String.format(REDIRECT_SPECIFICATION_DETAILS, specification.getId());
+        }
+        model.addAttribute(maybeSpecificationObjective.get());
+        return VIEWS_SPECIFICATION_OBJECTIVE_DETAILS;
+    }
+}

--- a/src/main/java/com/soam/web/specificationobjective/SpecificationObjectiveFormController.java
+++ b/src/main/java/com/soam/web/specificationobjective/SpecificationObjectiveFormController.java
@@ -22,16 +22,13 @@ import java.util.Optional;
 @RequestMapping("/specification/{specificationId}")
 public class SpecificationObjectiveFormController extends SoamFormController {
     private static final String VIEWS_SPECIFICATION_OBJECTIVE_ADD_OR_UPDATE_FORM = "specificationObjective/addUpdateSpecificationObjective";
-    private static final String VIEWS_SPECIFICATION_OBJECTIVE_DETAILS = "specificationObjective/specificationObjectiveDetails";
     private static final String REDIRECT_SPECIFICATION_LIST = "redirect:/specification/list";
-    private static final String REDIRECT_SPECIFICATION_DETAILS =  "redirect:/specification/%s";
+    private static final String REDIRECT_SPECIFICATION_OBJECTIVE_LIST = "redirect:/specification/%s/specificationObjective/list";
     private static final String REDIRECT_SPECIFICATION_OBJECTIVE_DETAILS = "redirect:/specification/%s/specificationObjective/%s";
 
     private final SpecificationObjectiveRepository specificationObjectives;
     private final ObjectiveTemplateRepository objectiveTemplates;
-
     private final SpecificationRepository specificationRepository;
-
     private final PriorityRepository priorities;
 
     public SpecificationObjectiveFormController(
@@ -47,18 +44,6 @@ public class SpecificationObjectiveFormController extends SoamFormController {
     public Specification populateSpecification(@PathVariable("specificationId") int specificationId){
         Optional<Specification> oSpecification = specificationRepository.findById(specificationId);
         return oSpecification.orElse(null);
-    }
-
-    @GetMapping("/specificationObjective/{specificationObjectiveId}")
-    public String showSpecificationObjective(
-            Specification specification,
-            @PathVariable("specificationObjectiveId") int specificationObjectiveId, Model model) {
-        Optional<SpecificationObjective> maybeSpecificationObjective = this.specificationObjectives.findById(specificationObjectiveId);
-        if (maybeSpecificationObjective.isEmpty()) {
-            return String.format(REDIRECT_SPECIFICATION_DETAILS, specification.getId());
-        }
-        model.addAttribute(maybeSpecificationObjective.get());
-        return VIEWS_SPECIFICATION_OBJECTIVE_DETAILS;
     }
 
     @GetMapping("/specificationObjective/new")
@@ -98,8 +83,8 @@ public class SpecificationObjectiveFormController extends SoamFormController {
             Specification specification,
             @PathVariable("specificationObjectiveId") int specificationObjectiveId, Model model) {
         Optional<SpecificationObjective> maybeSpecificationObjective = this.specificationObjectives.findById(specificationObjectiveId);
-        if(maybeSpecificationObjective.isEmpty()) {
-            return String.format(REDIRECT_SPECIFICATION_DETAILS, specification.getId());
+        if (maybeSpecificationObjective.isEmpty()) {
+            return String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, specification.getId());
         }
         model.addAttribute(maybeSpecificationObjective.get());
         populateFormModel(model);
@@ -141,18 +126,17 @@ public class SpecificationObjectiveFormController extends SoamFormController {
 
         if (maybeSpecificationObjective.isPresent()) {
             SpecificationObjective fetchedSpecificationObjective = maybeSpecificationObjective.get();
-            if(fetchedSpecificationObjective.getStakeholderObjectives() != null && !fetchedSpecificationObjective.getStakeholderObjectives().isEmpty()) {
+            if (fetchedSpecificationObjective.getStakeholderObjectives() != null && !fetchedSpecificationObjective.getStakeholderObjectives().isEmpty()) {
                 redirectAttributes.addFlashAttribute(Util.SUB_FLASH, "Please delete any stakeholder objectives first.");
-                return String.format(REDIRECT_SPECIFICATION_DETAILS, specification.getId());
+                return String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, specification.getId());
             }
 
             specificationObjectives.delete(fetchedSpecificationObjective);
             redirectAttributes.addFlashAttribute(Util.SUB_FLASH, String.format("Successfully deleted %s", fetchedSpecificationObjective.getName()));
-            return String.format(REDIRECT_SPECIFICATION_DETAILS, specification.getId());
         } else {
             redirectAttributes.addFlashAttribute(Util.DANGER, "Error deleting specification objective");
-            return String.format(REDIRECT_SPECIFICATION_DETAILS, specification.getId());
         }
+        return String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, specification.getId());
     }
 
     private void populateFormModel(Model model) {

--- a/src/main/java/com/soam/web/stakeholderobjective/StakeholderObjectiveFormController.java
+++ b/src/main/java/com/soam/web/stakeholderobjective/StakeholderObjectiveFormController.java
@@ -85,7 +85,8 @@ public class StakeholderObjectiveFormController extends SoamFormController {
             return String.format(REDIRECT_STAKEHOLDER_DETAILS, specification.getId(), stakeholder.getId());
         }
 
-        SpecificationObjective specificationObjective = specification.getSpecificationObjectives().get(0);
+        SpecificationObjective specificationObjective = new SpecificationObjective();
+        specificationObjective.setId(-1);
 
         StakeholderObjective stakeholderObjective = new StakeholderObjective();
         stakeholderObjective.setStakeholder(stakeholder);
@@ -107,15 +108,18 @@ public class StakeholderObjectiveFormController extends SoamFormController {
 
         Optional<SpecificationObjective> testSpecificationObjective = specificationObjectiveRepository.findById(specificationObjectiveId);
         if (testSpecificationObjective.isEmpty()) {
-            return String.format(REDIRECT_STAKEHOLDER_DETAILS, specification.getId(), stakeholder.getId());
-        }
+            SpecificationObjective emptySeSpecificationObjective = new SpecificationObjective();
+            emptySeSpecificationObjective.setId(-1);
+            stakeholderObjective.setSpecificationObjective(emptySeSpecificationObjective);
+            result.rejectValue("specificationObjective", "required", "Specification Objective should not be empty");
+        } else {
+            stakeholderObjective.setSpecificationObjective(testSpecificationObjective.get());
 
-        stakeholderObjective.setSpecificationObjective(testSpecificationObjective.get());
-
-        Optional<StakeholderObjective> testStakeholderObjective = stakeholderObjectives.findByStakeholderAndSpecificationObjectiveId(stakeholder, specificationObjectiveId);
-        if (testStakeholderObjective.isPresent()) {
-            testStakeholderObjective.get().setSpecificationObjective(testSpecificationObjective.get());
-            result.rejectValue("specificationObjective", "unique", "Stakeholder Objective already exists");
+            Optional<StakeholderObjective> testStakeholderObjective = stakeholderObjectives.findByStakeholderAndSpecificationObjectiveId(stakeholder, specificationObjectiveId);
+            if (testStakeholderObjective.isPresent()) {
+                testStakeholderObjective.get().setSpecificationObjective(testSpecificationObjective.get());
+                result.rejectValue("specificationObjective", "unique", "Stakeholder Objective already exists");
+            }
         }
 
         if (result.hasErrors()) {

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -3,6 +3,9 @@ DROP TABLE stakeholder_objectives IF EXISTS;
 DROP TABLE specification_objectives IF EXISTS;
 DROP TABLE stakeholders IF EXISTS;
 DROP TABLE specifications IF EXISTS;
+DROP TABLE specification_templates IF EXISTS;
+DROP TABLE stakeholder_templates IF EXISTS;
+DROP TABLE objective_templates IF EXISTS;
 
 
 CREATE TABLE priority_types (

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -78,7 +78,7 @@
         <li class="breadcrumb-item" th:classappend="${specification == null ? 'active' : ''}">
           <a th:href="@{/}">Home</a>
         </li>
-        <li class="breadcrumb-item" th:with="specificationActive=${stakeholder == null && specificationObjective == null}" th:classappend="${specificationActive ? 'active' : ''}" >
+        <li class="breadcrumb-item" th:with="specificationActive=${stakeholder == null && specificationObjective == null && specificationObjectives == null}" th:classappend="${specificationActive ? 'active' : ''}" >
           <a th:if="${specification['new']}">Specifications</a>
 
           <a th:if="${!specificationActive && !specification['new']}" th:text="${specification.name}"
@@ -90,6 +90,9 @@
           <a th:if="${!stakeholderActive && stakeholder.name != null }" th:text="${stakeholder.name}"
              th:href="@{/specification/__${specification.id}__/stakeholder/__${stakeholder.id}__}">Stakeholder Name</a>
           <span th:if="${stakeholderActive && stakeholder.name != null }" th:text="${stakeholder.name}">StakeholderName</span>
+        </li>
+        <li class="breadcrumb-item active" th:if="${specificationObjectives != null}">
+          <span>Specification Objectives</span>
         </li>
         <li class="breadcrumb-item active" th:if="${specificationObjective != null}">
           <a th:if="${specificationObjective.name == null}">Specification Objective</a>

--- a/src/main/resources/templates/specification/specificationDetails.html
+++ b/src/main/resources/templates/specification/specificationDetails.html
@@ -24,11 +24,13 @@
         <td th:text="*{priority}"></td>
       </tr>
     </table>
-    <div th:replace="~{fragments/flash :: subFlashMessage}"></div>
     <div class="row">
       <div class="col">
         <a th:href="@{__${specification.id}__/edit}" class="btn btn-primary">
           <i class="fa fa-pencil me-1" aria-hidden="true"></i> Edit Specification
+        </a>
+        <a th:href="@{__${specification.id}__/specificationObjective/list}" class="btn btn-primary ms-2">
+          <i class="fa fa-pencil me-1" aria-hidden="true"></i> Maintain Specification Objectives
         </a>
         <a class="btn btn-primary ms-2" onclick="if(confirm('Are you sure you want to delete this specification?')) document.getElementById('deleteForm').submit()"><i class="fa fa-trash-o me-2" aria-hidden="true"></i>Delete</a>
       </div>
@@ -56,30 +58,8 @@
         </tr>
         </tbody>
     </table>
+    <div th:replace="~{fragments/flash :: subFlashMessage}"></div>
     <a th:href="@{__${specification.id}__/stakeholder/new}" class="btn btn-primary"><i class="fa fa-plus me-1" aria-hidden="true"></i> Add Stakeholder</a>
-    </div>
-    <hr/>
-    <h2>Specification Objectives</h2>
-    <div class="col-md-10">
-      <div th:if="${#lists.isEmpty(specification.specificationObjectives)}" class="alert alert-warning">No Specification Objectives have been added to this specification.</div>
-      <table class="table table-striped" th:if="${!#lists.isEmpty(specification.specificationObjectives)}">
-        <thead>
-        <tr>
-          <th style="width: 350px;">Name</th>
-          <th>Priority</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="specificationObjective : ${specification.specificationObjectives}">
-          <td>
-            <a th:href="@{/specification/__${specification.id}__/specificationObjective/__${specificationObjective.id}__}" th:text="${specificationObjective.name}"/></a>
-          </td>
-          <td th:text="${specificationObjective.priority}"/>
-        </tr>
-        </tbody>
-      </table>
-      <a th:href="@{/specification/__${specification.id}__/specificationObjective/new}" class="btn btn-primary"><i class="fa fa-plus me-1" aria-hidden="true"></i> Add
-        Specification Objective</a>
     </div>
 
     <form id="deleteForm" th:object="${specification}" th:action="@{/specification/__${specification.id}__/delete}" method="post">

--- a/src/main/resources/templates/specificationobjective/specificationObjectiveList.html
+++ b/src/main/resources/templates/specificationobjective/specificationObjectiveList.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+<html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body}, ~{::head},'specificationObjectives')}">
+<head></head>
+<body>
+
+<h2>Specification Objectives</h2>
+<div class="alert alert-warning" th:if="${#lists.isEmpty(specificationObjectives)}">
+  No Specification Objectives have been added to this specification.
+</div>
+<table id="specificationObjectives" class="table table-striped" th:if="${!#lists.isEmpty(specificationObjectives)}">
+  <thead>
+  <tr>
+    <th style="width: 200px;">Name</th>
+    <th>Priority</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="specificationObjective : ${specificationObjectives}">
+    <td>
+      <a th:href="@{/specification/__${specificationObjective.specification.id}__/specificationObjective/__${specificationObjective.id}__}" th:text="${specificationObjective.name}"/></a>
+    </td>
+    <td th:text="${specificationObjective.priority}"/>
+  </tr>
+  </tbody>
+</table>
+
+<div>
+  <div th:replace="~{fragments/flash :: subFlashMessage}"></div>
+  <a th:href="@{/specification/__${specification.id}__/specificationObjective/new}" class="btn btn-primary"><i class="fa fa-plus me-1" aria-hidden="true"></i> Add
+        Specification Objective</a>
+</div>
+</body>
+</html>
+

--- a/src/test/java/com/soam/specificationobjective/SpecificationObjectiveControllerTest.java
+++ b/src/test/java/com/soam/specificationobjective/SpecificationObjectiveControllerTest.java
@@ -1,0 +1,98 @@
+package com.soam.specificationobjective;
+
+import com.soam.model.priority.PriorityType;
+import com.soam.model.specification.Specification;
+import com.soam.model.specification.SpecificationRepository;
+import com.soam.model.specificationobjective.SpecificationObjective;
+import com.soam.model.specificationobjective.SpecificationObjectiveRepository;
+import com.soam.web.specificationobjective.SpecificationObjectiveController;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SpecificationObjectiveController.class)
+public class SpecificationObjectiveControllerTest {
+    private static Specification TEST_SPECIFICATION = new Specification();
+    private static SpecificationObjective TEST_SPECIFICATION_OBJECTIVE = new SpecificationObjective();
+
+    private static final int EMPTY_SPECIFICATION_OBJECTIVE_ID = 999;
+
+    private static String URL_VIEW_SPECIFICATION_OBJECTIVE_LIST = "/specification/{specificationId}/specificationObjective/list";
+    private static String URL_VIEW_SPECIFICATION_OBJECTIVE = "/specification/{specificationId}/specificationObjective/{specificationObjectiveId}";
+
+    private static String VIEW_SPECIFICATION_OBJECTIVE_LIST = "specificationObjective/specificationObjectiveList";
+    private static String VIEW_SPECIFICATION_OBJECTIVE_DETAILS = "specificationObjective/specificationObjectiveDetails";
+
+    private static String REDIRECT_SPECIFICATION_DETAILS = "redirect:/specification/%s";
+
+    static {
+        PriorityType lowPriority = new PriorityType();
+        lowPriority.setName("Low");
+        lowPriority.setId(1);
+        lowPriority.setSequence(1);
+
+        TEST_SPECIFICATION.setId(10);
+        TEST_SPECIFICATION.setName("Test Specification");
+
+        TEST_SPECIFICATION_OBJECTIVE.setId(100);
+        TEST_SPECIFICATION_OBJECTIVE.setSpecification(TEST_SPECIFICATION);
+        TEST_SPECIFICATION_OBJECTIVE.setName("Test Spec 1");
+        TEST_SPECIFICATION_OBJECTIVE.setDescription("desc");
+        TEST_SPECIFICATION_OBJECTIVE.setNotes("notes");
+        TEST_SPECIFICATION_OBJECTIVE.setPriority(lowPriority);
+
+        TEST_SPECIFICATION.setSpecificationObjectives(Lists.newArrayList(TEST_SPECIFICATION_OBJECTIVE));
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SpecificationRepository specificationRepository;
+
+    @MockBean
+    private SpecificationObjectiveRepository specificationObjectives;
+
+    @BeforeEach
+    void setup() {
+        given(this.specificationRepository.findById(TEST_SPECIFICATION.getId())).willReturn(Optional.of(TEST_SPECIFICATION));
+
+        given(this.specificationObjectives.findAll()).willReturn(Lists.newArrayList(TEST_SPECIFICATION_OBJECTIVE));
+        given(this.specificationObjectives.findById(TEST_SPECIFICATION_OBJECTIVE.getId())).willReturn(Optional.of(TEST_SPECIFICATION_OBJECTIVE));
+    }
+
+    @Test
+    void testListAllSpecificationObjectives() throws Exception {
+        mockMvc.perform(get(URL_VIEW_SPECIFICATION_OBJECTIVE_LIST, TEST_SPECIFICATION.getId()))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("specification"))
+                .andExpect(model().attributeExists("specificationObjectives"))
+                .andExpect(view().name(VIEW_SPECIFICATION_OBJECTIVE_LIST));
+    }
+
+    @Test
+    void testViewSpecificationObjectiveDetails() throws Exception {
+        mockMvc.perform(get(URL_VIEW_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId(),  TEST_SPECIFICATION_OBJECTIVE.getId()))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("specificationObjective"))
+                .andExpect(model().attribute("specificationObjective", hasProperty("name", is(TEST_SPECIFICATION_OBJECTIVE.getName()))))
+                .andExpect(view().name(VIEW_SPECIFICATION_OBJECTIVE_DETAILS));
+
+        mockMvc.perform(get(URL_VIEW_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId(),
+                        EMPTY_SPECIFICATION_OBJECTIVE_ID))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name(String.format(REDIRECT_SPECIFICATION_DETAILS, TEST_SPECIFICATION.getId())));
+    }
+}

--- a/src/test/java/com/soam/specificationobjective/SpecificationObjectiveFormControllerTest.java
+++ b/src/test/java/com/soam/specificationobjective/SpecificationObjectiveFormControllerTest.java
@@ -38,12 +38,14 @@ public class SpecificationObjectiveFormControllerTest {
 
     private static final int EMPTY_SPECIFICATION_OBJECTIVE_ID = 999;
     
-    private static String URL_VIEW_SPECIFICATION_OBJECTIVE = "/specification/{specificationId}/specificationObjective/{specificationObjectiveId}";
     private static String URL_NEW_SPECIFICATION_OBJECTIVE = "/specification/{specificationId}/specificationObjective/new";
     private static String URL_EDIT_SPECIFICATION_OBJECTIVE = "/specification/{specificationId}/specificationObjective/{specificationObjectiveId}/edit";
     private static String URL_DELETE_SPECIFICATION_OBJECTIVE = "/specification/{specificationId}/specificationObjective/{specificationObjectiveId}/delete";
 
     private static String VIEW_EDIT_SPECIFICATION_OBJECTIVE =  "specificationObjective/addUpdateSpecificationObjective";
+
+    private static String REDIRECT_SPECIFICATION_OBJECTIVE_LIST = "redirect:/specification/%s/specificationObjective/list";
+    private static String REDIRECT_SPECIFICATION_OBJECTIVE_DETAILS = "redirect:/specification/%s/specificationObjective/%s";
 
     static {
         PriorityType lowPriority = new PriorityType();
@@ -120,20 +122,6 @@ public class SpecificationObjectiveFormControllerTest {
     }
 
     @Test
-    void testViewSpecificationObjectiveDetails() throws Exception {
-        mockMvc.perform(get(URL_VIEW_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId(),  TEST_SPECIFICATION_OBJECTIVE_1.getId()))
-                .andExpect(status().isOk())
-                .andExpect(model().attributeExists("specificationObjective"))
-                .andExpect(model().attribute("specificationObjective", hasProperty("name", is(TEST_SPECIFICATION_OBJECTIVE_1.getName()))))
-                .andExpect(view().name("specificationObjective/specificationObjectiveDetails"));
-
-        mockMvc.perform(get(URL_VIEW_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId(),
-                        EMPTY_SPECIFICATION_OBJECTIVE_ID))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(String.format("redirect:/specification/%s", TEST_SPECIFICATION.getId())));
-    }
-
-    @Test
     void testInitCreationForm() throws Exception {
         mockMvc.perform(get(URL_NEW_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId())).andExpect(status().isOk())
                 .andExpect(model().attributeExists("specificationObjective"))
@@ -186,7 +174,7 @@ public class SpecificationObjectiveFormControllerTest {
 
         mockMvc.perform(get(URL_EDIT_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId(), EMPTY_SPECIFICATION_OBJECTIVE_ID))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(String.format("redirect:/specification/%s",TEST_SPECIFICATION.getId())));
+                .andExpect(view().name(String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, TEST_SPECIFICATION.getId())));
     }
 
     @Test
@@ -197,7 +185,7 @@ public class SpecificationObjectiveFormControllerTest {
                         .param("description", "description there")
                         )
                     .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(String.format("redirect:/specification/%s/specificationObjective/%s",
+                .andExpect(view().name(String.format(REDIRECT_SPECIFICATION_OBJECTIVE_DETAILS,
                         TEST_SPECIFICATION.getId(), TEST_SPECIFICATION_OBJECTIVE_1.getId())));
     }
 
@@ -237,13 +225,13 @@ public class SpecificationObjectiveFormControllerTest {
                         .param("name", TEST_SPECIFICATION_OBJECTIVE_1.getName()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(flash().attributeExists(Util.SUB_FLASH))
-                .andExpect(view().name(String.format("redirect:/specification/%s", TEST_SPECIFICATION.getId())));
+                .andExpect(view().name(String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, TEST_SPECIFICATION.getId())));
 
         mockMvc.perform(post(URL_DELETE_SPECIFICATION_OBJECTIVE, TEST_SPECIFICATION.getId(), TEST_SPECIFICATION_OBJECTIVE_3.getId())
                         .param("name", TEST_SPECIFICATION_OBJECTIVE_3.getName()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(flash().attributeExists(Util.SUB_FLASH))
-                .andExpect(view().name(String.format("redirect:/specification/%s", TEST_SPECIFICATION.getId())));
+                .andExpect(view().name(String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, TEST_SPECIFICATION.getId())));
     }
 
     @Test
@@ -252,6 +240,6 @@ public class SpecificationObjectiveFormControllerTest {
                         .param("name", TEST_SPECIFICATION_OBJECTIVE_1.getName()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(flash().attributeExists(Util.DANGER))
-                .andExpect(view().name(String.format("redirect:/specification/%s", TEST_SPECIFICATION.getId())));
+                .andExpect(view().name(String.format(REDIRECT_SPECIFICATION_OBJECTIVE_LIST, TEST_SPECIFICATION.getId())));
     }
 }

--- a/src/test/java/com/soam/stakeholderobjective/StakeholderObjectiveFormControllerTest.java
+++ b/src/test/java/com/soam/stakeholderobjective/StakeholderObjectiveFormControllerTest.java
@@ -163,7 +163,9 @@ public class StakeholderObjectiveFormControllerTest {
                         .param("stakeholder", String.valueOf(TEST_STAKEHOLDER.getId()))
                         .param("specificationObjective", String.valueOf(EMPTY_SPECIFICATION_OBJECTIVE_ID))
                         .param("templateId", String.valueOf(EMPTY_SPECIFICATION_OBJECTIVE_ID)))
-                .andExpect(status().is3xxRedirection());
+                .andExpect(model().hasErrors())
+                .andExpect(model().attributeHasFieldErrors("stakeholderObjective", "specificationObjective"))
+                .andExpect(status().isOk());
 
         mockMvc.perform(post(URL_NEW_STAKEHOLDER_OBJECTIVE, TEST_SPECIFICATION.getId(), TEST_STAKEHOLDER.getId())
                         .param("stakeholder", String.valueOf(TEST_STAKEHOLDER.getId()))


### PR DESCRIPTION
1. Added new `Maintain Specification Objectives` button to the Specification Info page and dedicated Specification Objective Listing page which acts as a starting point for all Specification Objective CRUD actions.
2. Newly created Stakeholder Objective is blank by default, User must explicitly pick one of Specification Objectives in order to create Stakeholder Objective now.
3. Added `DROP TABLE` calls for all DB tables present in the product.